### PR TITLE
避免使用相对路径使用相对路径。

### DIFF
--- a/src/GB2260.php
+++ b/src/GB2260.php
@@ -9,7 +9,7 @@ class GB2260
 
     public function __construct()
     {
-        $this->data = require 'data.php';
+        $this->data = require __DIR__.'/data.php';
     }
 
     public function get($code)


### PR DESCRIPTION
避免使用相对路径，在PHP的解析当中可以避免多余的文件系统查找。
